### PR TITLE
Fix: Icon optimisation

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -1,0 +1,48 @@
+multipass: true
+
+plugins:
+  - addAttributesToSVGElement: false
+  - addClassesToSVGElement: false
+  - cleanupAttrs: true
+  - cleanupEnableBackground: true
+  - cleanupIDs: true
+  - cleanupListOfValues: true
+  - cleanupNumericValues:
+      floatPrecision: 2
+  - collapseGroups: true
+  - convertColors: true
+  - convertPathData: true
+  - convertShapeToPath: false
+  - convertStyleToAttrs: true
+  - convertTransform: true
+  - mergePaths: true
+  - minifyStyles: true
+  - moveElemsAttrsToGroup: true
+  - moveGroupAttrsToElems: true
+  - removeAttrs:
+      attrs:
+        - 'aria-labelledby'
+  - removeComments: true
+  - removeDesc: true
+  - removeDimensions: true
+  - removeDoctype: true
+  - removeEditorsNSData: true
+  - removeElementsByAttr: true
+  - removeEmptyAttrs: true
+  - removeEmptyContainers: true
+  - removeEmptyText: true
+  - removeHiddenElems: true
+  - removeMetadata: true
+  - removeNonInheritableGroupAttrs: true
+  - removeRasterImages
+  - removeStyleElement: true
+  - removeTitle: true
+  - removeUnknownsAndDefaults: true
+  - removeUnusedNS: true
+  - removeUselessDefs: true
+  - removeUselessStrokeAndFill: true
+  - removeViewBox: true
+  - removeXMLNS: false
+  - removeXMLProcInst: true
+  - sortAttrs: true
+  - transformsWithOnePath: true

--- a/scripts/build-export.mjs
+++ b/scripts/build-export.mjs
@@ -17,8 +17,6 @@ import pkg from '../package.json'
 const templateExport = (name) =>
   `export { ReactComponent as ${changeCase.pascalCase(
     name
-  )}, default as ${changeCase.snakeCase(
-    name
   )} } from './node_modules/ikonate/icons/${name}.svg'\n`
 
 /**


### PR DESCRIPTION
- Minor update to add custom SVGO options as Ikonate uses some _tricky to optimise_ SVG elements & needed to remove the `aria-labelledby`
- Removed string export as unnecessary for initial release