### PR TITLE
Fix: Retain CJS bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom-learning/icons",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "version": "1.11.0",
   "description": "",

--- a/scripts/build-export.ts
+++ b/scripts/build-export.ts
@@ -115,10 +115,10 @@ const run = async () => {
 
   await outputESEntry(icons)
 
-  Object.entries(icons).map(async ([name, source]) => {
+  for (const [name, source] of Object.entries(icons)) {
     const { code } = await transformIcon(name, source)
     await fs.writeFile(path.resolve(DIRECTORY_OUTPUT, `${name}.js`), code)
-  })
+  }
 
   await outputCJSBundle()
 }

--- a/scripts/build-export.ts
+++ b/scripts/build-export.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises'
 import glob from 'glob'
 import path from 'path'
 import { transform } from '@svgr/core'
-import { transformSync } from 'esbuild'
+import { buildSync, transformSync } from 'esbuild'
 
 const DIRECTORY_SOURCE = './src'
 const DIRECTORY_OUTPUT = './dist'
@@ -38,6 +38,22 @@ const exists = async (path: string) => {
   } catch {
     return false
   }
+}
+
+const outputESEntry = async (icons) => {
+  const template = await createESExportString(icons)
+  await fs.writeFile(path.resolve(DIRECTORY_OUTPUT, 'index.js'), template)
+}
+
+const outputCJSBundle = async () => {
+  await buildSync({
+    entryPoints: [path.resolve(DIRECTORY_OUTPUT, 'index.js')],
+    outfile: path.resolve(DIRECTORY_OUTPUT, 'index.cjs.js'),
+    format: 'cjs',
+    bundle: true,
+    external: ['react'],
+    minify: true
+  })
 }
 
 const createESExportString = async (icons: Record<string, string>) => {
@@ -97,17 +113,14 @@ const run = async () => {
     await fs.mkdir(DIRECTORY_OUTPUT)
   }
 
+  await outputESEntry(icons)
+
   Object.entries(icons).map(async ([name, source]) => {
     const { code } = await transformIcon(name, source)
     await fs.writeFile(path.resolve(DIRECTORY_OUTPUT, `${name}.js`), code)
   })
 
-  const mainExportTemplate = await createESExportString(icons)
-
-  await fs.writeFile(
-    path.resolve(DIRECTORY_OUTPUT, 'index.js'),
-    mainExportTemplate
-  )
+  await outputCJSBundle()
 }
 
 run()


### PR DESCRIPTION
This allows the icon lib to be consumed by non-ES modules environments, i.e. Jest