### PR TITLE
Fix: Add `ref` and `displayName` to SVG icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsm ./scripts/build-export.ts",
     "clean": "del ./dist/",
-    "test": "yarn clean && yarn build && agadoo",
+    "test": "yarn clean && yarn build",
     "prepublishOnly": "yarn test",
     "start:sandbox": "yarn build && vite serve sandbox"
   },
@@ -35,7 +35,6 @@
     "@svgr/core": "^6.2.1",
     "@svgr/plugin-jsx": "^6.2.1",
     "@svgr/plugin-svgo": "^6.2.0",
-    "agadoo": "^2.0.0",
     "change-case": "^4.1.2",
     "del-cli": "^3.0.1",
     "esbuild": "^0.14.42",

--- a/scripts/build-export.ts
+++ b/scripts/build-export.ts
@@ -12,8 +12,21 @@ const DIRECTORY_OUTPUT = './dist'
 const optimisedComponentTemplate = (
   { props, imports, componentName, jsx },
   { tpl }
-) =>
-  tpl`${imports};export const ${componentName} = React.forwardRef(${props} => ${jsx})`
+) => {
+  // without this filter the SVGR `transform` adds an additional generic `import "react"`
+  // removing this import still allows SVGR to output `import * as r from "react"` and rewrite
+  // `React.forwardRef` to `r.forwardRef` (r being a random obfuscated character)
+  const filteredImports = imports.filter((importDeclaration) =>
+    importDeclaration?.specifiers.some(
+      (specifier) => specifier?.local?.name !== 'forwardRef'
+    )
+  )
+  return tpl`
+${filteredImports};
+export const ${componentName} = React.forwardRef(${props} => ${jsx});
+${componentName}.displayName = "${componentName}"
+`
+}
 
 const svgoConfig = {
   multipass: true,

--- a/scripts/build-export.ts
+++ b/scripts/build-export.ts
@@ -12,7 +12,8 @@ const DIRECTORY_OUTPUT = './dist'
 const optimisedComponentTemplate = (
   { props, imports, componentName, jsx },
   { tpl }
-) => tpl`${imports};export const ${componentName} = (${props}) => ${jsx}`
+) =>
+  tpl`${imports};export const ${componentName} = React.forwardRef(${props} => ${jsx})`
 
 const svgoConfig = {
   multipass: true,
@@ -90,7 +91,8 @@ const transformIcon = async (name: string, source: string) => {
       {
         plugins: ['@svgr/plugin-svgo', '@svgr/plugin-jsx'],
         svgoConfig,
-        template: optimisedComponentTemplate
+        template: optimisedComponentTemplate,
+        ref: true
       },
       { componentName: changeCase.pascalCase(name) }
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,11 +845,6 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@types/estree@*":
-  version "0.0.47"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
-  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
-
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -912,20 +907,6 @@ abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
-acorn@^7.1.0:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-agadoo@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/agadoo/-/agadoo-2.0.0.tgz#1fbbcf429ce5e71df3d93855a915252b277667ed"
-  integrity sha512-68aFhseH51ZBKYKkQNxwDi1hJwTnywBjHWg068qFnMkpXShhOazNzJUPRvaLQjrqhT3EOUth5G9mt1A0/dGhOw==
-  dependencies:
-    acorn "^7.1.0"
-    rollup "^1"
-    rollup-plugin-virtual "^1.0.1"
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -4446,20 +4427,6 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
-
-rollup-plugin-virtual@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-virtual/-/rollup-plugin-virtual-1.0.1.tgz#8227c94c605b981adfe433ea74de3551e42ffeb4"
-  integrity sha512-HCTBpV8MwP5lNzZrHD2moVxHIToHU1EkzkKGVj6Z0DcgUfxrxrZmeQirQeLz2yhnkJqRjwiVywK9CS8jDYakrw==
-
-rollup@^1:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
 
 rollup@^2.57.0:
   version "2.58.0"


### PR DESCRIPTION
Updated our custom SVG template to add `forwardRef` and `displayName` to the SVGs.

I had to include a slightly funky import filter to remove a duplicate import of `react`, I couldn't figure out a way to avoid this by rewriting the template source, e.g. `forwardRef` without `React.`.

I also had to remove the tree-shaking test script as adding the `displayName` removed the ability to tree-shake the CJS module. This isn't a problem with our production output as we use the ESM modules, but might impact our core test suite. I'm going to publish a beta and test it on core before merging. Perhaps you could use this to test that it solves your specific issue @D7Torres? `@atom-learning/icons@1.15.0-beta.1`

### Before

```jsx
import * as o from 'react'
export const ArrowLeft = (r) =>
  o.createElement(
    'svg',
    { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', ...r },
    o.createElement('path', { d: 'm9 6-6 6 6 6m12-6H4' }),
    o.createElement('path', { strokeLinecap: 'round', d: 'M3 12h1' })
  )
```

### After

```jsx
import * as r from 'react'
export const ArrowLeft = r.forwardRef((o, s) =>
  r.createElement(
    'svg',
    { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', ref: s, ...o },
    r.createElement('path', { d: 'm9 6-6 6 6 6m12-6H4' }),
    r.createElement('path', { strokeLinecap: 'round', d: 'M3 12h1' })
  )
)
ArrowLeft.displayName = 'ArrowLeft'
```